### PR TITLE
#9: add a delay before enabling RX

### DIFF
--- a/src/MobusRTUSlave.cpp
+++ b/src/MobusRTUSlave.cpp
@@ -202,6 +202,7 @@ void ModbusRTUSlave::_write(uint8_t len) {
     if (_dePin != 255) digitalWrite(_dePin, HIGH);
     _serial->write(_buf, len + 2);
     _serial->flush();
+    delay(1);
     if (_dePin != 255) digitalWrite(_dePin, LOW);
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Introduced a 1 millisecond delay after data writing to enhance stability and reliability of Modbus communication.
  
- **Bug Fixes**
    - Improved timing control in the communication process to prevent potential data transmission issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->